### PR TITLE
remove oracle jdk from travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,6 @@ language: java
 
 jdk:
   - openjdk8
-  - oraclejdk8
-
-addons:
-  apt:
-    packages:
-      - oracle-java8-set-default
 
 env:
   - SAXON_CP=saxon/saxon9he.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ jdk:
   - openjdk8
   - oraclejdk8
 
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
 env:
   - SAXON_CP=saxon/saxon9he.jar
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jdk:
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - oracle-java8-set-default
 
 env:
   - SAXON_CP=saxon/saxon9he.jar


### PR DESCRIPTION
oracle-jdk8 retrieval does not work reliably, so just drop it.